### PR TITLE
Fix plugin tooltip

### DIFF
--- a/src/view.tsx
+++ b/src/view.tsx
@@ -5,7 +5,7 @@ import MyCalendar from './components/calendar';
 import { createRoot, Root } from 'react-dom/client';
 
 export const VIEW_TYPE = 'calendar';
-export const VIEW_DISPLAY_TEXT = 'Calendar';
+export const VIEW_DISPLAY_TEXT = 'HW Calendar';
 export const ICON = 'CALENDAR_ICON';
 
 export class CalendarView extends ItemView {


### PR DESCRIPTION
## Summary
- rename view display text constant to 'HW Calendar'

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6840ec81a644832f9b614b66f8b95b4b