### PR TITLE
Prefix week numbers

### DIFF
--- a/src/components/calendar.tsx
+++ b/src/components/calendar.tsx
@@ -120,8 +120,8 @@ export default function MyCalendar(params: { plugin: CalendarPlugin }) {
 				// @ts-ignore - This prop exists in react-calendar but might not be in the type definitions
 				formatDay={(_locale, date) => dayjs(date).format('D')}
 				// Custom prop to format week numbers - might not be in type definitions
-				// @ts-ignore
-				formatWeekNumber={(weekNumber) => `${weekNumber}`}
+                                // @ts-ignore
+                                formatWeekNumber={(weekNumber) => `W${weekNumber.toString().padStart(2, '0')}`}
 			/>
 			<>
 				<div id="calendar-divider"></div>


### PR DESCRIPTION
## Summary
- show week numbers with a `W` prefix in the calendar

## Testing
- `npm run build` *(fails: Cannot find module 'obsidian' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6851bcbbc8f0832f9464aba514663970